### PR TITLE
Add scope support to CLI commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .secrets
 secrets*
 vendor
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Environment variable export format option
 - Import command supporting json and yaml formats
 - Delete command
+- Scope support
+  - Manage scopes using `secret scope`
+  - Pass a `--scope` to any command to operate on a scope
 
 ### Changed
 - Better error logging

--- a/commands/del.go
+++ b/commands/del.go
@@ -1,15 +1,24 @@
 package commands
 
 import (
+	"fmt"
+
 	cli "github.com/urfave/cli"
 
 	"github.com/bugcrowd/secrets/libsecrets"
 )
 
-// Set sets a value in secrets
+// Del deletes a value from secrets
 func Del(c *cli.Context) {
-	scope, err := libsecrets.GetScope("default")
+	scopeName := c.String("scope")
+	scope, err := libsecrets.GetScope(scopeName)
+
 	if err != nil {
+		g.LogError(err)
+	}
+
+	if len(c.Args()) != 1 {
+		err = fmt.Errorf("The del command requires exactly one argument")
 		g.LogError(err)
 	}
 

--- a/commands/del.go
+++ b/commands/del.go
@@ -8,7 +8,7 @@ import (
 
 // Set sets a value in secrets
 func Del(c *cli.Context) {
-	scope, err := libsecrets.NewScope("default")
+	scope, err := libsecrets.GetScope("default")
 	if err != nil {
 		g.LogError(err)
 	}

--- a/commands/export.go
+++ b/commands/export.go
@@ -10,7 +10,7 @@ import (
 
 // Export gets all values from the secrets
 func Export(c *cli.Context) {
-	scope, err := libsecrets.NewScope("default")
+	scope, err := libsecrets.GetScope("default")
 	if err != nil {
 		g.LogError(err)
 	}

--- a/commands/export.go
+++ b/commands/export.go
@@ -10,7 +10,8 @@ import (
 
 // Export gets all values from the secrets
 func Export(c *cli.Context) {
-	scope, err := libsecrets.GetScope("default")
+	scopeName := c.String("scope")
+	scope, err := libsecrets.GetScope(scopeName)
 	if err != nil {
 		g.LogError(err)
 	}

--- a/commands/get.go
+++ b/commands/get.go
@@ -10,8 +10,8 @@ import (
 
 // Get gets a value by key from a scope
 func Get(c *cli.Context) {
-	context := c.GlobalString("context")
-	scope, err := libsecrets.GetScope(context)
+	scopeName := c.GlobalString("scope")
+	scope, err := libsecrets.GetScope(scopeName)
 
 	if err != nil {
 		g.LogError(err)

--- a/commands/get.go
+++ b/commands/get.go
@@ -11,22 +11,14 @@ import (
 // Get gets a value by key from a scope
 func Get(c *cli.Context) {
 	context := c.GlobalString("context")
+	scope, err := libsecrets.GetScope(context)
 
-	scope, err := libsecrets.NewScope(context)
 	if err != nil {
 		g.LogError(err)
 	}
 
-	if !scope.Exists() {
-		scope, err = libsecrets.CreateScope(context)
-
-		if err != nil {
-			g.LogError(err)
-		}
-	}
-
 	if len(c.Args()) != 1 {
-		err := fmt.Errorf("The get command requires exactly one argument")
+		err = fmt.Errorf("The get command requires exactly one argument")
 		g.LogError(err)
 	}
 

--- a/commands/get.go
+++ b/commands/get.go
@@ -10,9 +10,19 @@ import (
 
 // Get gets a value by key from a scope
 func Get(c *cli.Context) {
-	scope, err := libsecrets.NewScope("default")
+	context := c.GlobalString("context")
+
+	scope, err := libsecrets.NewScope(context)
 	if err != nil {
 		g.LogError(err)
+	}
+
+	if !scope.Exists() {
+		scope, err = libsecrets.CreateScope(context)
+
+		if err != nil {
+			g.LogError(err)
+		}
 	}
 
 	if len(c.Args()) != 1 {

--- a/commands/get.go
+++ b/commands/get.go
@@ -10,7 +10,7 @@ import (
 
 // Get gets a value by key from a scope
 func Get(c *cli.Context) {
-	scopeName := c.GlobalString("scope")
+	scopeName := c.String("scope")
 	scope, err := libsecrets.GetScope(scopeName)
 
 	if err != nil {

--- a/commands/import.go
+++ b/commands/import.go
@@ -11,7 +11,7 @@ import (
 
 // Export gets all values from the secrets
 func Import(c *cli.Context) {
-	scope, err := libsecrets.NewScope("default")
+	scope, err := libsecrets.GetScope("default")
 	if err != nil {
 		g.LogError(err)
 	}

--- a/commands/import.go
+++ b/commands/import.go
@@ -9,9 +9,10 @@ import (
 	"github.com/bugcrowd/secrets/libsecrets"
 )
 
-// Export gets all values from the secrets
+// Import bulk adds data to a secrets scope
 func Import(c *cli.Context) {
-	scope, err := libsecrets.GetScope("default")
+	scopeName := c.String("scope")
+	scope, err := libsecrets.GetScope(scopeName)
 	if err != nil {
 		g.LogError(err)
 	}

--- a/commands/init.go
+++ b/commands/init.go
@@ -23,15 +23,7 @@ func Init(c *cli.Context) {
 	}
 
 	// TODO: Create initial scopes
-	scope, err := libsecrets.NewScope("default")
-	if err != nil {
-		g.LogError(err)
-	}
-
-	err = scope.Save()
-	if err != nil {
-		g.LogError(err)
-	}
+	libsecrets.CreateScope("default")
 
 	g.Log.Info("Initialized empty secrets repository at %s", g.Dir())
 }

--- a/commands/init.go
+++ b/commands/init.go
@@ -23,7 +23,12 @@ func Init(c *cli.Context) {
 	}
 
 	// TODO: Create initial scopes
-	_, err := libsecrets.CreateScope("default")
+	scope, err := libsecrets.NewScope("default")
+	if err != nil {
+		g.LogError(err)
+	}
+
+	err = scope.Save()
 	if err != nil {
 		g.LogError(err)
 	}

--- a/commands/members.go
+++ b/commands/members.go
@@ -43,7 +43,7 @@ func loadMembersFromArgs(c *cli.Context) ([]*libsecrets.Member, error) {
 
 // MembersList gets all or a specific value from the secrets
 func MembersList(c *cli.Context) {
-	scope, err := libsecrets.NewScope("default")
+	scope, err := libsecrets.GetScope("default")
 	if err != nil {
 		g.LogError(err)
 	}
@@ -55,7 +55,7 @@ func MembersList(c *cli.Context) {
 
 // MembersAdd add a new member to the scope
 func MembersAdd(c *cli.Context) {
-	scope, err := libsecrets.NewScope("default")
+	scope, err := libsecrets.GetScope("default")
 	if err != nil {
 		g.LogError(err)
 	}
@@ -83,7 +83,7 @@ func MembersAdd(c *cli.Context) {
 
 // MembersRemove add a new member to the scope
 func MembersRemove(c *cli.Context) {
-	scope, err := libsecrets.NewScope("default")
+	scope, err := libsecrets.GetScope("default")
 	if err != nil {
 		g.LogError(err)
 	}

--- a/commands/members.go
+++ b/commands/members.go
@@ -43,7 +43,8 @@ func loadMembersFromArgs(c *cli.Context) ([]*libsecrets.Member, error) {
 
 // MembersList gets all or a specific value from the secrets
 func MembersList(c *cli.Context) {
-	scope, err := libsecrets.GetScope("default")
+	scopeName := c.String("scope")
+	scope, err := libsecrets.GetScope(scopeName)
 	if err != nil {
 		g.LogError(err)
 	}
@@ -55,7 +56,8 @@ func MembersList(c *cli.Context) {
 
 // MembersAdd add a new member to the scope
 func MembersAdd(c *cli.Context) {
-	scope, err := libsecrets.GetScope("default")
+	scopeName := c.String("scope")
+	scope, err := libsecrets.GetScope(scopeName)
 	if err != nil {
 		g.LogError(err)
 	}
@@ -78,12 +80,17 @@ func MembersAdd(c *cli.Context) {
 		return
 	}
 
-	g.Log.Notice("Added members %s", strings.Join(libsecrets.GetMemberListIdentifiers(membersAdded), ", "))
+	g.Log.Notice(
+		"Added members %s to scope \"%s\"",
+		strings.Join(libsecrets.GetMemberListIdentifiers(membersAdded), ", "),
+		scope.Name,
+	)
 }
 
 // MembersRemove add a new member to the scope
 func MembersRemove(c *cli.Context) {
-	scope, err := libsecrets.GetScope("default")
+	scopeName := c.String("scope")
+	scope, err := libsecrets.GetScope(scopeName)
 	if err != nil {
 		g.LogError(err)
 	}
@@ -95,5 +102,9 @@ func MembersRemove(c *cli.Context) {
 		g.LogError(err)
 	}
 
-	g.Log.Notice("Removed members %s", strings.Join(libsecrets.GetMemberListIdentifiers(membersRemoved), ", "))
+	g.Log.Notice(
+		"Removed members %s from scope \"%s\"",
+		strings.Join(libsecrets.GetMemberListIdentifiers(membersRemoved), ", "),
+		scope.Name,
+	)
 }

--- a/commands/scope.go
+++ b/commands/scope.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	cli "github.com/urfave/cli"
 
@@ -33,5 +35,13 @@ func ScopeRemove(c *cli.Context) {
 
 // ScopeList lists all scopes
 func ScopeList(c *cli.Context) {
-	fmt.Println("scope list")
+	dir := g.Dir()
+	files, _ := filepath.Glob(dir + "/*.keybase")
+
+	for i := 0; i < len(files); i++ {
+		file := files[i]
+		basename := filepath.Base(file)
+		filename := strings.TrimSuffix(basename, filepath.Ext(basename))
+		fmt.Println(filename)
+	}
 }

--- a/commands/scope.go
+++ b/commands/scope.go
@@ -29,14 +29,26 @@ func ScopeAdd(c *cli.Context) {
 
 // ScopeRemove removes a scope
 func ScopeRemove(c *cli.Context) {
-	scope := c.String("scope")
-	fmt.Printf("scope remove %s", scope)
+	args := c.Args()
+
+	if len(args) != 1 {
+		err := fmt.Errorf("The remove command requires exactly one argument")
+		g.LogError(err)
+	}
+	scope := args[0]
+	err := libsecrets.RemoveScope(scope)
+
+	if err != nil {
+		err := fmt.Errorf("Error removing the \"%s\" scope: %s", scope, err)
+		g.LogError(err)
+	}
+
+	g.Log.Notice("Removed the \"%s\" scope", scope)
 }
 
 // ScopeList lists all scopes
 func ScopeList(c *cli.Context) {
-	dir := g.Dir()
-	files, _ := filepath.Glob(dir + "/*.keybase")
+	files, _ := filepath.Glob(g.Dir() + "/*.keybase")
 
 	for i := 0; i < len(files); i++ {
 		file := files[i]

--- a/commands/scope.go
+++ b/commands/scope.go
@@ -4,14 +4,25 @@ import (
 	"fmt"
 
 	cli "github.com/urfave/cli"
-)
 
-// "github.com/bugcrowd/secrets/libsecrets"
+	"github.com/bugcrowd/secrets/libsecrets"
+)
 
 // ScopeAdd creates a new scope
 func ScopeAdd(c *cli.Context) {
-	scope := c.String("scope")
-	fmt.Printf("scope add %s", scope)
+	args := c.Args()
+
+	if len(args) != 1 {
+		err := fmt.Errorf("The add command requires exactly one argument")
+		g.LogError(err)
+	}
+
+	scope, err := libsecrets.CreateScope(args[0])
+	if err != nil {
+		g.LogError(err)
+	}
+
+	g.Log.Notice("Created the \"%s\" scope", scope.Name)
 }
 
 // ScopeRemove removes a scope

--- a/commands/scope.go
+++ b/commands/scope.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"fmt"
+
+	cli "github.com/urfave/cli"
+)
+
+// "github.com/bugcrowd/secrets/libsecrets"
+
+// ScopeAdd creates a new scope
+func ScopeAdd(c *cli.Context) {
+	scope := c.String("scope")
+	fmt.Printf("scope add %s", scope)
+}
+
+// ScopeRemove removes a scope
+func ScopeRemove(c *cli.Context) {
+	scope := c.String("scope")
+	fmt.Printf("scope remove %s", scope)
+}
+
+// ScopeList lists all scopes
+func ScopeList(c *cli.Context) {
+	fmt.Println("scope list")
+}

--- a/commands/set.go
+++ b/commands/set.go
@@ -11,9 +11,19 @@ import (
 
 // Set sets a value in secrets
 func Set(c *cli.Context) {
-	scope, err := libsecrets.NewScope("default")
+	context := c.GlobalString("context")
+
+	scope, err := libsecrets.NewScope(context)
 	if err != nil {
 		g.LogError(err)
+	}
+
+	if !scope.Exists() {
+		scope, err = libsecrets.CreateScope(context)
+
+		if err != nil {
+			g.LogError(err)
+		}
 	}
 
 	kv := strings.SplitN(c.Args().First(), "=", 2)

--- a/commands/set.go
+++ b/commands/set.go
@@ -11,7 +11,7 @@ import (
 
 // Set sets a value in secrets
 func Set(c *cli.Context) {
-	scopeName := c.GlobalString("scope")
+	scopeName := c.String("scope")
 
 	scope, err := libsecrets.GetScope(scopeName)
 	if err != nil {

--- a/commands/set.go
+++ b/commands/set.go
@@ -11,9 +11,9 @@ import (
 
 // Set sets a value in secrets
 func Set(c *cli.Context) {
-	context := c.GlobalString("context")
+	scopeName := c.GlobalString("scope")
 
-	scope, err := libsecrets.GetScope(context)
+	scope, err := libsecrets.GetScope(scopeName)
 	if err != nil {
 		g.LogError(err)
 	}

--- a/commands/set.go
+++ b/commands/set.go
@@ -13,17 +13,9 @@ import (
 func Set(c *cli.Context) {
 	context := c.GlobalString("context")
 
-	scope, err := libsecrets.NewScope(context)
+	scope, err := libsecrets.GetScope(context)
 	if err != nil {
 		g.LogError(err)
-	}
-
-	if !scope.Exists() {
-		scope, err = libsecrets.CreateScope(context)
-
-		if err != nil {
-			g.LogError(err)
-		}
 	}
 
 	kv := strings.SplitN(c.Args().First(), "=", 2)

--- a/libsecrets/scope.go
+++ b/libsecrets/scope.go
@@ -59,6 +59,23 @@ func CreateScope(name string) (scope *Scope, err error) {
 	return scope, nil
 }
 
+// RemoveScope deletes an existing scope
+func RemoveScope(name string) (err error) {
+	scope := NewScope(name)
+	path := scope.KeybaseSinkPath()
+
+	if !scope.Exists() {
+		return fmt.Errorf("The \"%s\" scope does not exist", name)
+	}
+
+	err = os.Remove(path)
+	if err != nil {
+		return err
+	}
+
+	return
+}
+
 // MakeScopeLocation constructs the path of a scope
 func makeScopePath(name string) string {
 	return G.Dir() + "/" + name
@@ -110,7 +127,7 @@ func (s *Scope) KeybaseSinkPath() string {
 // Load reads the secret scope from disk
 func (s *Scope) Load() error {
 	if !s.Exists() {
-		return fmt.Errorf("Can not load scope %s from location %s. No such file", s.Name, s.Path())
+		return fmt.Errorf("The \"%s\" scope does not exist", s.Name)
 	}
 
 	src := client.NewFileSource(s.KeybaseSinkPath())

--- a/libsecrets/scope.go
+++ b/libsecrets/scope.go
@@ -26,7 +26,7 @@ type ImportOptions struct {
 // NewScope instantiates a Scope struct.
 // If the Scope already exists then creation will fail.
 // In that case use `GetScope`.
-func NewScope(name string) (scope *Scope, err error) {
+func NewScope(name string) (scope *Scope) {
 	scope = &Scope{
 		Name:    name,
 		Members: make([]Member, 0),
@@ -38,10 +38,25 @@ func NewScope(name string) (scope *Scope, err error) {
 
 // GetScope returns an existing Scope
 func GetScope(name string) (scope *Scope, err error) {
-	scope, err = NewScope(name)
+	scope = NewScope(name)
 	err = scope.Load()
 
 	return scope, err
+}
+
+// CreateScope creates a new Scope and saves it to disk.
+func CreateScope(name string) (scope *Scope, err error) {
+	scope = NewScope(name)
+	if scope.Exists() {
+		return nil, fmt.Errorf("The \"%s\" scope already exists", scope.Name)
+	}
+
+	err = scope.Save()
+	if err != nil {
+		return nil, err
+	}
+
+	return scope, nil
 }
 
 // MakeScopeLocation constructs the path of a scope

--- a/libsecrets/scope.go
+++ b/libsecrets/scope.go
@@ -31,7 +31,7 @@ func NewScope(name string) (scope *Scope, err error) {
 	}
 
 	// Load existing data if it exists
-	if scope.exists() {
+	if scope.Exists() {
 		err = scope.Load()
 	}
 
@@ -76,7 +76,8 @@ func fileExists(path string) bool {
 	return false
 }
 
-func (s *Scope) exists() bool {
+// Exists returns whether the scope has already been persisted
+func (s *Scope) Exists() bool {
 	return fileExists(s.KeybaseSinkPath())
 }
 
@@ -107,7 +108,7 @@ func (s *Scope) KeybaseSinkPath() string {
 
 // Load reads the secret scope from disk
 func (s *Scope) Load() error {
-	if !s.exists() {
+	if !s.Exists() {
 		return fmt.Errorf("Can not load scope %s from location %s. No such file", s.Name, s.Path())
 	}
 

--- a/libsecrets/scope.go
+++ b/libsecrets/scope.go
@@ -17,6 +17,7 @@ type Scope struct {
 	Data    map[string]string
 }
 
+// ImportOptions is a set of options for importing secrets
 type ImportOptions struct {
 	Format string
 	regex  *regexp.Regexp
@@ -76,22 +77,22 @@ func fileExists(path string) bool {
 	return false
 }
 
-// Exists returns whether the scope has already been persisted
+// Exists returns whether a Scope exists on disk
 func (s *Scope) Exists() bool {
 	return fileExists(s.KeybaseSinkPath())
 }
 
-// Get returns a secret from
+// Get returns a secret from a Scope
 func (s *Scope) Get(key string) string {
 	return s.Data[key]
 }
 
-// Set returns a secret from
+// Set returns a secret from a Scope
 func (s *Scope) Set(key string, value string) {
 	s.Data[key] = value
 }
 
-// Set returns a secret from
+// Del deletes a secret from a Scope
 func (s *Scope) Del(key string) {
 	delete(s.Data, key)
 }
@@ -124,7 +125,7 @@ func (s *Scope) Load() error {
 	return json.Unmarshal(sink.Bytes(), &s)
 }
 
-// AddMembers adds a list of members to the scope
+// AddMembers adds a list of members to the Scope
 func (s *Scope) AddMembers(members []*Member, adder *Member) []*Member {
 	membersAdded := []*Member{}
 
@@ -145,7 +146,7 @@ func (s *Scope) AddMembers(members []*Member, adder *Member) []*Member {
 	return membersAdded
 }
 
-// AddMembers adds a list of members to the scope
+// RemoveMembersByIdentifiers removes members from a Scope
 func (s *Scope) RemoveMembersByIdentifiers(members []string) []*Member {
 	membersKept := []Member{}
 	membersRemoved := []*Member{}
@@ -207,7 +208,7 @@ func (s *Scope) Save() error {
 	return Encrypt(src, sink, GetMemberListIdentifiers(s.MemberPointers()))
 }
 
-// Export returns this scopes data in the request format
+// Export returns this Scope's data in the requested format
 func (s *Scope) Export(format string) (string, error) {
 	var formatter Formatter
 
@@ -227,6 +228,7 @@ func (s *Scope) Export(format string) (string, error) {
 	return formatter.String(), nil
 }
 
+// Import adds `contents` to the Scope with the given options
 func (s *Scope) Import(contents string, options ImportOptions) error {
 	var parser Importer
 

--- a/main.go
+++ b/main.go
@@ -16,6 +16,12 @@ var (
 func main() {
 	libsecrets.G.Init()
 
+	scopeFlag := cli.StringFlag{
+		Name:  "scope, s",
+		Value: "default",
+		Usage: "Scope to use",
+	}
+
 	app := cli.NewApp()
 	app.Name = "Secrets"
 	app.Usage = "Managing your application secrets"
@@ -36,13 +42,7 @@ func main() {
 				commands.Get(c)
 				return nil
 			},
-			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  "scope, s",
-					Value: "default",
-					Usage: "Scope to use",
-				},
-			},
+			Flags: []cli.Flag{scopeFlag},
 		},
 		{
 			Name:  "set",
@@ -51,13 +51,7 @@ func main() {
 				commands.Set(c)
 				return nil
 			},
-			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  "scope, s",
-					Value: "default",
-					Usage: "Scope to use",
-				},
-			},
+			Flags: []cli.Flag{scopeFlag},
 		},
 		{
 			Name:    "del",
@@ -67,18 +61,13 @@ func main() {
 				commands.Del(c)
 				return nil
 			},
-			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  "scope, s",
-					Value: "default",
-					Usage: "Scope to use",
-				},
-			},
+			Flags: []cli.Flag{scopeFlag},
 		},
 		{
 			Name:  "export",
 			Usage: "Export all data in a scope",
 			Flags: []cli.Flag{
+				scopeFlag,
 				cli.StringFlag{
 					Name:  "format, f",
 					Value: "human",
@@ -94,6 +83,7 @@ func main() {
 			Name:  "import",
 			Usage: "Import data into a scope",
 			Flags: []cli.Flag{
+				scopeFlag,
 				cli.StringFlag{
 					Name:  "format, f",
 					Value: "env",
@@ -121,22 +111,25 @@ func main() {
 						commands.MembersList(c)
 						return nil
 					},
+					Flags: []cli.Flag{scopeFlag},
 				},
 				{
 					Name:  "add",
-					Usage: "Add members",
+					Usage: "Add members to a scope",
 					Action: func(c *cli.Context) error {
 						commands.MembersAdd(c)
 						return nil
 					},
+					Flags: []cli.Flag{scopeFlag},
 				},
 				{
 					Name:  "remove",
-					Usage: "Remove members",
+					Usage: "Remove members from a scope",
 					Action: func(c *cli.Context) error {
 						commands.MembersRemove(c)
 						return nil
 					},
+					Flags: []cli.Flag{scopeFlag},
 				},
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -36,6 +36,13 @@ func main() {
 				commands.Get(c)
 				return nil
 			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "scope, s",
+					Value: "default",
+					Usage: "Scope to use",
+				},
+			},
 		},
 		{
 			Name:  "set",
@@ -43,6 +50,13 @@ func main() {
 			Action: func(c *cli.Context) error {
 				commands.Set(c)
 				return nil
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "scope, s",
+					Value: "default",
+					Usage: "Scope to use",
+				},
 			},
 		},
 		{
@@ -52,6 +66,13 @@ func main() {
 			Action: func(c *cli.Context) error {
 				commands.Del(c)
 				return nil
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "scope, s",
+					Value: "default",
+					Usage: "Scope to use",
+				},
 			},
 		},
 		{
@@ -119,13 +140,35 @@ func main() {
 				},
 			},
 		},
-	}
-
-	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:  "scope,s",
-			Value: "default",
-			Usage: "scope for the operation",
+		{
+			Name:  "scope",
+			Usage: "Scope management",
+			Subcommands: []cli.Command{
+				{
+					Name:  "list",
+					Usage: "List existing scopes",
+					Action: func(c *cli.Context) error {
+						commands.ScopeList(c)
+						return nil
+					},
+				},
+				{
+					Name:  "add",
+					Usage: "Add a new scope",
+					Action: func(c *cli.Context) error {
+						commands.ScopeAdd(c)
+						return nil
+					},
+				},
+				{
+					Name:  "remove",
+					Usage: "Remove a scope",
+					Action: func(c *cli.Context) error {
+						commands.ScopeRemove(c)
+						return nil
+					},
+				},
+			},
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -120,6 +120,15 @@ func main() {
 			},
 		},
 	}
+	var context string
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:        "context,c",
+			Value:       "default",
+			Usage:       "context for the operation",
+			Destination: &context,
+		},
+	}
 
 	app.Run(os.Args)
 }

--- a/main.go
+++ b/main.go
@@ -120,13 +120,12 @@ func main() {
 			},
 		},
 	}
-	var context string
+
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:        "context,c",
-			Value:       "default",
-			Usage:       "context for the operation",
-			Destination: &context,
+			Name:  "scope,s",
+			Value: "default",
+			Usage: "scope for the operation",
 		},
 	}
 


### PR DESCRIPTION
Very rough spike of what this might look like. Some questions:

* Checking if the context exists before operating on it in each command will get old pretty fast. Some potential solutions:
   * Do we want to allow lazily adding new context, or force contexts to be created explicitly?
     * This would prevent accidentally creating a new context, e.g. passing `--devleopment`, or `--dev` when using the longer form, etc.
  * We can change the `Scope` interface to a find-or-create pattern.
    * It's better to abstract this away from the commands so we can handle it in a uniform way
* The `-c` flag is often used for specifying configuration files. Do we want to reserve it and use something else?
* Is it fine to use context as a global flag, or should it be implemented only on a subset of commands?
* What should be the behavior of `get` or `export` when dealing with multiple contexts?
  * Do env-specifics override global?
  * Do we show both when there are conflicts?
  * Does `export` or `get` without a flag only fetch from the default context, or should it look in all contexts?
  * Do we want to make a environment variable available to change this behavior, which could be useful in applications?